### PR TITLE
Update php-cs-fixer package

### DIFF
--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -5,4 +5,4 @@ require 'vendor/autoload.php';
 $finder = PhpCsFixer\Finder::create()
     ->in(__DIR__ . '/src/');
 
-return K10r\Codestyle\PHP74::create($finder);
+return K10r\Codestyle\PHP80::create($finder);

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,6 @@
     }
   },
   "require": {
-    "friendsofphp/php-cs-fixer": "^3.12"
+    "friendsofphp/php-cs-fixer": "^3.16"
   }
 }

--- a/src/Fixer/AutomaticCommentsFixer.php
+++ b/src/Fixer/AutomaticCommentsFixer.php
@@ -25,24 +25,24 @@ final class AutomaticCommentsFixer extends AbstractFixer
             [
                 new CodeSample(
                     <<<'EOT'
-<?php
+                        <?php
 
-namespace Project\TheNamespace;
+                        namespace Project\TheNamespace;
 
-/**
- * Class TheClass
- */
-class TheClass
-{
-    /**
-     * TheClass constructor.
-     */
-    public function __construct()
-    {
+                        /**
+                         * Class TheClass
+                         */
+                        class TheClass
+                        {
+                            /**
+                             * TheClass constructor.
+                             */
+                            public function __construct()
+                            {
 
-    }
-}
-EOT
+                            }
+                        }
+                        EOT
                 ),
             ]
         );

--- a/src/Fixer/MultiToSingleLineAnnotationFixer.php
+++ b/src/Fixer/MultiToSingleLineAnnotationFixer.php
@@ -25,23 +25,23 @@ final class MultiToSingleLineAnnotationFixer extends AbstractFixer
             [
                 new CodeSample(
                     <<<'EOT'
-<?php
+                        <?php
 
-namespace Project\TheNamespace;
+                        namespace Project\TheNamespace;
 
-class TheClass
-{
-    /**
-     * @var int
-     */
-    public $property;
+                        class TheClass
+                        {
+                            /**
+                             * @var int
+                             */
+                            public $property;
 
-    /**
-     * @var string
-     */
-    public $otherProperty;
-}
-EOT
+                            /**
+                             * @var string
+                             */
+                            public $otherProperty;
+                        }
+                        EOT
                 ),
             ]
         );


### PR DESCRIPTION
This PR will update the `friendsofphp/php-cs-fixer` package to `^3.16`.

# Main reason
`friendsofphp/php-cs-fixer` at former `^3.12` requires an older version of `doctrine/annotations` which conflicts with `shopware/core` at `6.4.0.0` and above.

# Addition

Bumped the local php-cs-fixer config to use `PHP80::create` and applied it to this project.